### PR TITLE
Disable attachment section for uploaded file page and its siblings #92

### DIFF
--- a/ui/src/main/resources/FileManagerCode/FileSheet.xml
+++ b/ui/src/main/resources/FileManagerCode/FileSheet.xml
@@ -39,6 +39,7 @@
   <content>{{include reference="FileManagerCode.Macros" /}}
 
 {{velocity output="false"}}
+#set ($showattachments = false)
 #macro (handleFileWebServiceRequest)
   #if ($request.action)
     #if ($services.csrf.isTokenValid($request.form_token))


### PR DESCRIPTION
Disabled the attachments section for files in File manager.