### PR TITLE
Two folders having the same name, except one with a trailing space character, are displayed two times #79

### DIFF
--- a/ui/src/main/resources/FileManagerCode/Macros.xml
+++ b/ui/src/main/resources/FileManagerCode/Macros.xml
@@ -142,10 +142,11 @@ $!text.replace('$', '${escapetool.d}').replace('#', '${escapetool.h}')
 #end
 
 #macro (createFolder $name $parent)
+  ## Trimming whitespaces from the input name to address potential issues with the database collation which may lead to
+  ## unexpected behavior when dealing with trailing whitespaces.
+  #set ($name = $name.trim())
   #if ("$!name" == '')
     #set ($name = 'Untitled Folder')
-  #else
-    #set ($name = $name.trim())
   #end
   #set ($folderReference = $services.drive.getUniqueReference($name))
   #if ("$!parent" == '')

--- a/ui/src/main/resources/FileManagerCode/Macros.xml
+++ b/ui/src/main/resources/FileManagerCode/Macros.xml
@@ -144,6 +144,8 @@ $!text.replace('$', '${escapetool.d}').replace('#', '${escapetool.h}')
 #macro (createFolder $name $parent)
   #if ("$!name" == '')
     #set ($name = 'Untitled Folder')
+  #else
+    #set ($name = $name.trim())
   #end
   #set ($folderReference = $services.drive.getUniqueReference($name))
   #if ("$!parent" == '')


### PR DESCRIPTION
Added a trim to the input name of the folder so that any trailing spaces are removed. Opted for this solution, as the issue does not seem to be related to the application backend. The problem may be caused by the fact that a utf8mb4_bin Collation is used on the database which has a [pad space attribute](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-sets.html#charset-unicode-sets-pad-attributes).

This solution also fixes issue #78.