### PR TITLE
Folder download does not produce the correct archive after you replace its content #99

### DIFF
--- a/api/src/main/java/org/xwiki/filemanager/internal/job/PackJob.java
+++ b/api/src/main/java/org/xwiki/filemanager/internal/job/PackJob.java
@@ -115,6 +115,7 @@ public class PackJob extends AbstractJob<PackRequest, PackJobStatus>
         AttachmentReference outputFileReference = getRequest().getOutputFileReference();
         TemporaryResourceReference temporaryResourceReference = new TemporaryResourceReference(MODULE_NAME,
             Collections.singletonList(outputFileReference.getName()), outputFileReference.getParent());
+        temporaryResourceReference.addParameter("jobId", request.getId().get(1));
         File outputFile = this.temporaryResourceStore.createTemporaryFile(temporaryResourceReference,
             new ByteArrayInputStream(new byte[] {}));
         String pathPrefix = "";

--- a/api/src/main/java/org/xwiki/filemanager/internal/job/PackJob.java
+++ b/api/src/main/java/org/xwiki/filemanager/internal/job/PackJob.java
@@ -34,6 +34,7 @@ import javax.inject.Named;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.filemanager.FileSystem;
 import org.xwiki.filemanager.Folder;
@@ -115,7 +116,7 @@ public class PackJob extends AbstractJob<PackRequest, PackJobStatus>
         AttachmentReference outputFileReference = getRequest().getOutputFileReference();
         TemporaryResourceReference temporaryResourceReference = new TemporaryResourceReference(MODULE_NAME,
             Collections.singletonList(outputFileReference.getName()), outputFileReference.getParent());
-        temporaryResourceReference.addParameter("jobId", request.getId().get(1));
+        temporaryResourceReference.addParameter("jobId", StringUtils.join(request.getId(), "/"));
         File outputFile = this.temporaryResourceStore.createTemporaryFile(temporaryResourceReference,
             new ByteArrayInputStream(new byte[] {}));
         String pathPrefix = "";

--- a/api/src/test/java/org/xwiki/filemanager/internal/job/PackJobTest.java
+++ b/api/src/test/java/org/xwiki/filemanager/internal/job/PackJobTest.java
@@ -106,9 +106,10 @@ public class PackJobTest extends AbstractJobTest
         AttachmentReference packReference =
             new AttachmentReference("out.zip", new DocumentReference("wiki", Arrays.asList("Path", "To"), "Page"));
         request.setOutputFileReference(packReference);
-
+        request.setId("id1", "id2");
         TemporaryResourceReference packResourceReference = new TemporaryResourceReference("filemanager",
             Collections.singletonList("out.zip"), packReference.getParent());
+        packResourceReference.addParameter("jobId", request.getId().get(1));
         java.io.File packFile = new java.io.File(testFolder.getRoot(), "temp/filemanager/wiki/Path/To/Page/out.zip");
         packFile.getParentFile().mkdirs();
         packFile.createNewFile();

--- a/api/src/test/java/org/xwiki/filemanager/internal/job/PackJobTest.java
+++ b/api/src/test/java/org/xwiki/filemanager/internal/job/PackJobTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.zip.ZipFile;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -109,7 +110,7 @@ public class PackJobTest extends AbstractJobTest
         request.setId("id1", "id2");
         TemporaryResourceReference packResourceReference = new TemporaryResourceReference("filemanager",
             Collections.singletonList("out.zip"), packReference.getParent());
-        packResourceReference.addParameter("jobId", request.getId().get(1));
+        packResourceReference.addParameter("jobId", StringUtils.join(request.getId(), "/"));
         java.io.File packFile = new java.io.File(testFolder.getRoot(), "temp/filemanager/wiki/Path/To/Page/out.zip");
         packFile.getParentFile().mkdirs();
         packFile.createNewFile();

--- a/ui/src/main/resources/FileManagerCode/DriveSheet.xml
+++ b/ui/src/main/resources/FileManagerCode/DriveSheet.xml
@@ -142,7 +142,7 @@
 #end
 
 #macro (getDownloadDocument $name $title $return)
-  #set ($downloadId = "Download-$!{xcontext.userReference.name}-${name}")
+  #set ($downloadId = "Download-$!{xcontext.userReference.name}-$name")
   #set ($downloadDocRef = $services.model.createDocumentReference($downloadId,
     $doc.documentReference.lastSpaceReference))
   #set ($downloadDoc = $xwiki.getDocument($downloadDocRef))

--- a/ui/src/main/resources/FileManagerCode/DriveSheet.xml
+++ b/ui/src/main/resources/FileManagerCode/DriveSheet.xml
@@ -142,7 +142,8 @@
 #end
 
 #macro (getDownloadDocument $name $title $return)
-  #set ($downloadId = "Download-$!{xcontext.userReference.name}-$name")
+  #set ($currentTimeMillis = $datetool.date.time)
+  #set ($downloadId = "Download-$!{xcontext.userReference.name}-${name}-${currentTimeMillis}")
   #set ($downloadDocRef = $services.model.createDocumentReference($downloadId,
     $doc.documentReference.lastSpaceReference))
   #set ($downloadDoc = $xwiki.getDocument($downloadDocRef))

--- a/ui/src/main/resources/FileManagerCode/DriveSheet.xml
+++ b/ui/src/main/resources/FileManagerCode/DriveSheet.xml
@@ -142,8 +142,7 @@
 #end
 
 #macro (getDownloadDocument $name $title $return)
-  #set ($currentTimeMillis = $datetool.date.time)
-  #set ($downloadId = "Download-$!{xcontext.userReference.name}-${name}-${currentTimeMillis}")
+  #set ($downloadId = "Download-$!{xcontext.userReference.name}-${name}")
   #set ($downloadDocRef = $services.model.createDocumentReference($downloadId,
     $doc.documentReference.lastSpaceReference))
   #set ($downloadDoc = $xwiki.getDocument($downloadDocRef))


### PR DESCRIPTION
Added the job ID as a parameter to the temporary file reference to ensure that every download URL is unique and the browser is not using an old reference from the cache.