### PR TITLE
Can't access a folder that was copied in another folder #80

### DIFF
--- a/ui/src/main/resources/FileManagerCode/Macros.xml
+++ b/ui/src/main/resources/FileManagerCode/Macros.xml
@@ -136,11 +136,6 @@
   #setVariable("$return" $results.size().equals(1))
 #end
 
-## $escapetool.velocity() doesn't work as expected (XCOMMONS-2367) so we can't use it.
-#macro (escapeVelocity $text)
-$!text.replace('$', '${escapetool.d}').replace('#', '${escapetool.h}')
-#end
-
 #macro (createFolder $name $parent)
   ## Trimming whitespaces from the input name to address potential issues with the database collation which may lead to
   ## unexpected behavior when dealing with trailing whitespaces.
@@ -160,7 +155,7 @@ $!text.replace('$', '${escapetool.d}').replace('#', '${escapetool.h}')
   ## used page name is not exactly the folder name given by the user (e.g. when the user creates the folder "Test" we
   ## might have to create the page "Test13" with the title "Test").
   $response.sendRedirect($xwiki.getURL($folderReference, 'save', $escapetool.url({
-    'title': "#escapeVelocity($name)",
+    'title': $escapetool.velocity($name),
     'parent': $services.model.serialize($parentReference, 'compactwiki'),
     'template': 'FileManagerCode.FolderTemplate',
     'comment': 'Folder created',


### PR DESCRIPTION
The issue was caused by an additional line break that was added when `#escapeVelocity($name)` macro was called.
Replaced custom `escapeVelocity` macro with `$escapetool.velocity`, as the issue [XCOMMONS-2367](https://jira.xwiki.org/browse/XCOMMONS-2367) which prevented the use of the `$escapetool.velocity` has been fixed in version 13.10.3 and the new LTS is now 14.10.