### PR TITLE
 File Manager Pro does not respect the naming strategy set at wiki level when saving pages #36 

### DIFF
--- a/api/src/main/java/org/xwiki/filemanager/internal/reference/DefaultUniqueDocumentReferenceGenerator.java
+++ b/api/src/main/java/org/xwiki/filemanager/internal/reference/DefaultUniqueDocumentReferenceGenerator.java
@@ -46,7 +46,7 @@ import org.xwiki.model.validation.EntityNameValidationManager;
 /**
  * Implements {@link UniqueDocumentReferenceGenerator} using a cache to reserve document references for a period of
  * time.
- * 
+ *
  * @version $Id$
  * @since 2.0RC1
  */
@@ -86,20 +86,21 @@ public class DefaultUniqueDocumentReferenceGenerator
      */
     @Inject
     private ComponentManager componentManager;
-    
+
     /**
      * Transform a name according to the current name strategy, if the configuration is set to use transformation.
-     * Else it will just return the given name.
+     * Otherwise, it will just return the given name.
+     * <p>
+     * Taken from {@link org.xwiki.model.validation.script.ModelValidationScriptService#transformName}
      *
-     * Taken from org.xwiki.model.validation.script.ModelValidationScriptService
-     *
-     * @param name the name to transform.
-     * @return the transformed named.
+     * @param name the name to transform
+     * @return the transformed name according to the current name strategy
      */
     private String transformName(String name)
     {
         if (this.entityNameValidationConfiguration != null && this.entityNameValidationConfiguration.useTransformation()
-                && this.entityNameValidationManager.getEntityReferenceNameStrategy() != null) {
+            && this.entityNameValidationManager.getEntityReferenceNameStrategy() != null)
+        {
             return this.entityNameValidationManager.getEntityReferenceNameStrategy().transform(name);
         } else {
             return name;

--- a/api/src/test/java/org/xwiki/filemanager/internal/reference/DefaultUniqueDocumentReferenceGeneratorTest.java
+++ b/api/src/test/java/org/xwiki/filemanager/internal/reference/DefaultUniqueDocumentReferenceGeneratorTest.java
@@ -29,11 +29,15 @@ import org.xwiki.cache.config.CacheConfiguration;
 import org.xwiki.filemanager.reference.UniqueDocumentReferenceGenerator;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.model.validation.EntityNameValidation;
+import org.xwiki.model.validation.EntityNameValidationConfiguration;
+import org.xwiki.model.validation.EntityNameValidationManager;
 import org.xwiki.test.annotation.BeforeComponent;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,6 +58,21 @@ public class DefaultUniqueDocumentReferenceGeneratorTest
 
     @SuppressWarnings("unchecked")
     private Cache<Boolean> documentReferenceCache = mock(Cache.class);
+
+    EntityNameValidationManager entityNameValidationManager;
+
+    EntityNameValidationConfiguration entityNameValidationConfiguration;
+
+    EntityNameValidation entityNameValidation;
+
+    @BeforeComponent
+    public void initializeNameValidation() throws Exception
+    {
+        entityNameValidationManager = this.mocker.registerMockComponent(EntityNameValidationManager.class);
+        entityNameValidationConfiguration = this.mocker.registerMockComponent(EntityNameValidationConfiguration.class);
+        entityNameValidation = this.mocker.registerMockComponent(EntityNameValidation.class);
+        when(entityNameValidationManager.getEntityReferenceNameStrategy()).thenReturn(this.entityNameValidation);
+    }
 
     @BeforeComponent
     public void initializeCache() throws Exception
@@ -94,5 +113,28 @@ public class DefaultUniqueDocumentReferenceGeneratorTest
 
         assertEquals(spaceReference, secondReference.getLastSpaceReference());
         assertEquals("foo2", secondReference.getName());
+    }
+
+    @Test
+    public void namingStrategy() throws Exception {
+        String pageName = "Te st ed";
+        SpaceReference spaceReference =
+                new DocumentReference("gang", "Drive", pageName).getLastSpaceReference();
+        DocumentReference docReference;
+
+        when(entityNameValidation.transform(anyString())).thenAnswer(
+                i -> ((String) (i.getArguments()[0])).replace(' ', '-')
+        );
+
+        when(entityNameValidationConfiguration.useTransformation()).thenReturn(true);
+        docReference =
+                this.mocker.getComponentUnderTest().generate(spaceReference, new DocumentNameSequence(pageName));
+        assertEquals("Te-st-ed", docReference.getName());
+
+
+        when(entityNameValidationConfiguration.useTransformation()).thenReturn(false);
+        docReference =
+                this.mocker.getComponentUnderTest().generate(spaceReference, new DocumentNameSequence(pageName));
+        assertEquals(pageName, docReference.getName());
     }
 }

--- a/api/src/test/java/org/xwiki/filemanager/internal/reference/DefaultUniqueDocumentReferenceGeneratorTest.java
+++ b/api/src/test/java/org/xwiki/filemanager/internal/reference/DefaultUniqueDocumentReferenceGeneratorTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link DefaultUniqueDocumentReferenceGenerator}.
- * 
+ *
  * @version $Id$
  * @since 2.0RC1
  */
@@ -52,7 +52,7 @@ public class DefaultUniqueDocumentReferenceGeneratorTest
 {
     @Rule
     public MockitoComponentMockingRule<UniqueDocumentReferenceGenerator> mocker =
-        new MockitoComponentMockingRule<UniqueDocumentReferenceGenerator>(DefaultUniqueDocumentReferenceGenerator.class);
+        new MockitoComponentMockingRule<>(DefaultUniqueDocumentReferenceGenerator.class);
 
     private DocumentAccessBridge documentAccessBridge;
 
@@ -116,25 +116,25 @@ public class DefaultUniqueDocumentReferenceGeneratorTest
     }
 
     @Test
-    public void namingStrategy() throws Exception {
+    public void generateWithNamingStrategy() throws Exception
+    {
         String pageName = "Te st ed";
         SpaceReference spaceReference =
-                new DocumentReference("gang", "Drive", pageName).getLastSpaceReference();
+            new DocumentReference("gang", "Drive", pageName).getLastSpaceReference();
         DocumentReference docReference;
 
         when(entityNameValidation.transform(anyString())).thenAnswer(
-                i -> ((String) (i.getArguments()[0])).replace(' ', '-')
+            i -> ((String) (i.getArguments()[0])).replace(' ', '-')
         );
 
         when(entityNameValidationConfiguration.useTransformation()).thenReturn(true);
         docReference =
-                this.mocker.getComponentUnderTest().generate(spaceReference, new DocumentNameSequence(pageName));
+            this.mocker.getComponentUnderTest().generate(spaceReference, new DocumentNameSequence(pageName));
         assertEquals("Te-st-ed", docReference.getName());
-
 
         when(entityNameValidationConfiguration.useTransformation()).thenReturn(false);
         docReference =
-                this.mocker.getComponentUnderTest().generate(spaceReference, new DocumentNameSequence(pageName));
+            this.mocker.getComponentUnderTest().generate(spaceReference, new DocumentNameSequence(pageName));
         assertEquals(pageName, docReference.getName());
     }
 }


### PR DESCRIPTION
Page names created with File Manager Pro are now correctly transformed according to the wiki naming strategy. The transformation applies only to the page name, so the displayed title in the UI remains unchanged.

![image](https://github.com/user-attachments/assets/3f009504-12d5-4c26-8b7c-90d61d0eb2f8)