### PR TITLE
Accessibility improvement

### DIFF
--- a/ui/src/main/resources/FileManagerCode/DriveSheet.xml
+++ b/ui/src/main/resources/FileManagerCode/DriveSheet.xml
@@ -250,14 +250,14 @@
           ng-click="drive.viewer = 'upload'" type="button"
           title="$services.localization.render('fileManager.action.newFileHint')"&gt;
         &lt;img src="$xwiki.getSkinFile('icons/silk/page_white_add.png')" class="icon"
-          alt="$services.localization.render('fileManager.action.newFile')" /&gt;
+          alt="" /&gt;
         $services.localization.render('fileManager.action.newFile')
       &lt;/button&gt;
     &lt;/div&gt;&lt;div class="btn-group" dropdown&gt;
       &lt;button type="button" class="btn btn-default" title="$services.localization.render('fileManager.action.downloadFilesHint')"
           ng-disabled="drive.readOnly || selectedFiles.length == 0" ng-click="download(selectedFiles)"&gt;
         &lt;img src="$xwiki.getSkinFile('icons/silk/page_white_put.png')" class="icon"
-          alt="$services.localization.render('fileManager.action.download')" /&gt;
+          alt="" /&gt;
         $services.localization.render('fileManager.action.download')
       &lt;/button&gt;
       &lt;button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle&gt;
@@ -274,20 +274,20 @@
       &lt;button type="button" class="btn btn-default" title="$services.localization.render('fileManager.action.cutFilesHint')"
           ng-disabled="drive.readOnly || !canCut(selectedFiles)" ng-click="cut(selectedFiles)"&gt;
         &lt;img src="$xwiki.getSkinFile('icons/silk/cut.png')" class="icon"
-          alt="$services.localization.render('fileManager.action.cut')" /&gt;
+          alt="" /&gt;
         $services.localization.render('fileManager.action.cut')
       &lt;/button&gt;
       &lt;button type="button" class="btn btn-default" title="$services.localization.render('fileManager.action.copyFilesHint')"
           ng-disabled="drive.readOnly || !canCopy(selectedFiles)" ng-click="copy(selectedFiles)"&gt;
         &lt;img src="$xwiki.getSkinFile('icons/silk/page_white_copy.png')" class="icon"
-          alt="$services.localization.render('fileManager.action.copy')" /&gt;
+          alt="" /&gt;
         $services.localization.render('fileManager.action.copy')
       &lt;/button&gt;
       &lt;button type="button" class="btn btn-default" title="$services.localization.render('fileManager.action.pasteHint')"
           ng-if="drive.location.type == 'drive' || drive.location.type == 'folder'"
           ng-disabled="!clipboard" ng-click="paste()"&gt;
         &lt;img src="$xwiki.getSkinFile('icons/silk/page_white_paste.png')" class="icon"
-          alt="$services.localization.render('fileManager.action.paste')" /&gt;
+          alt="" /&gt;
         $services.localization.render('fileManager.action.paste')
       &lt;/button&gt;
     &lt;/div&gt;&lt;div class="btn-group"&gt;
@@ -295,13 +295,13 @@
           ng-disabled="drive.readOnly || selectedFiles.length != 1 || !selectedFiles[0].canRename"
           ng-click="rename(selectedFiles[0])"&gt;
         &lt;img src="$xwiki.getSkinFile('icons/silk/textfield_rename.png')" class="icon"
-          alt="$services.localization.render('fileManager.action.rename')" /&gt;
+          alt="" /&gt;
         $services.localization.render('fileManager.action.rename')
       &lt;/button&gt;
       &lt;button type="button" class="btn btn-default" title="$services.localization.render('fileManager.action.deleteFilesHint')"
           ng-disabled="drive.readOnly || !canDelete(selectedFiles)" ng-click="delete(selectedFiles)"&gt;
         &lt;img src="$xwiki.getSkinFile('icons/silk/cross.png')" class="icon"
-          alt="$services.localization.render('fileManager.action.delete')" /&gt;
+          alt="" /&gt;
         $services.localization.render('fileManager.action.delete')
       &lt;/button&gt;
     &lt;/div&gt;
@@ -319,7 +319,7 @@
       &lt;button type="button" class="btn btn-default" title="$services.localization.render('fileManager.action.backToFileList')"
           ng-if="back" ng-click="back()"&gt;
         &lt;img src="$xwiki.getSkinFile('icons/silk/arrow_left.png')" class="icon"
-          alt="$services.localization.render('fileManager.action.back')" /&gt;
+          alt="" /&gt;
         $services.localization.render('fileManager.action.back')
       &lt;/button&gt;
     &lt;/div&gt;
@@ -381,7 +381,7 @@
         &lt;button type="button" class="btn btn-default" ng-click="drive.viewer = 'files'"
             title="$services.localization.render('fileManager.action.backToFileList')"&gt;
           &lt;img src="$xwiki.getSkinFile('icons/silk/arrow_left.png')" class="icon"
-            alt="$services.localization.render('fileManager.action.back')" /&gt;
+            alt="" /&gt;
           $services.localization.render('fileManager.action.back')
         &lt;/button&gt;
       &lt;/div&gt;
@@ -3090,8 +3090,8 @@ require(['jquery', 'angular', 'JobRunner', 'xwiki-l10n!filemanager-drivesheet-tr
 #files img.icon,
 .upload img.icon,
 .jobs img.avatar {
-  max-height: 32px;
-  max-width: 32px;
+  max-height: 3.2rem;
+  max-width: 3.2rem;
 }
 #files thead.xwiki-livetable-display-header td.xwiki-livetable-display-header-filter input {
   /* Overwrite the default padding. */
@@ -3099,7 +3099,7 @@ require(['jquery', 'angular', 'JobRunner', 'xwiki-l10n!filemanager-drivesheet-tr
 }
 
 #files .folder {
-  color: #777777;
+  color: $theme.textColor;
   font-size: small;
   font-weight: normal;
   text-transform: none;
@@ -3276,7 +3276,7 @@ table.pane-splitter .pane-content {
   left: 0;
   list-style: none outside none;
   margin: 2px 0 0;
-  min-width: 160px;
+  min-width: 16rem;
   padding: 5px 0;
   position: absolute;
   top: 100%;
@@ -3387,7 +3387,7 @@ li.download img.icon {
   background-color: $theme.pageBackgroundColor;
   border-radius: 4px;
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1) inset;
-  height: 15px;
+  height: 1.5rem;
   margin: 3px 0;
   overflow: hidden;
 }

--- a/ui/src/main/resources/FileManagerCode/FileSheet.xml
+++ b/ui/src/main/resources/FileManagerCode/FileSheet.xml
@@ -128,7 +128,7 @@
       ## URL factory encodes the anchor badly, messing the ? and = characters.
       &lt;a href="$xwiki.getURL($driveReference)#?driveNode=$escapetool.url($driveNode)" class="btn btn-default"
           title="Back to the File Manager"&gt;
-        &lt;img src="$xwiki.getSkinFile('icons/silk/arrow_left.png')" alt="Back" class="icon" /&gt;
+        &lt;img src="$xwiki.getSkinFile('icons/silk/arrow_left.png')" alt="" class="icon" /&gt;
         $services.localization.render('fileManager.action.backToFileManager')
       &lt;/a&gt;
     &lt;/div&gt;
@@ -141,7 +141,7 @@
     &lt;div class="btn-group"&gt;
       &lt;a href="$doc.getAttachmentURL($attachments.get(0).filename, 'download', 'force-download=1')"
           class="btn btn-default" title="Download this file"&gt;
-        &lt;img src="$xwiki.getSkinFile('icons/silk/page_white_put.png')" alt="Download" class="icon" /&gt;
+        &lt;img src="$xwiki.getSkinFile('icons/silk/page_white_put.png')" alt="" class="icon" /&gt;
         $services.localization.render('fileManager.action.download')
       &lt;/a&gt;
     &lt;/div&gt;


### PR DESCRIPTION
Removed redundant alt text and modified folder path text color to theme text color.

Old folder path text color:
<img width="2112" height="304" alt="image" src="https://github.com/user-attachments/assets/3ffde814-c03d-4cd3-914b-3279484af012" />

<img width="2108" height="322" alt="image" src="https://github.com/user-attachments/assets/d51cbce3-937b-4097-9807-4ebdbd88bb09" />

New folder path text color:
<img width="2276" height="518" alt="image" src="https://github.com/user-attachments/assets/0e932202-0f00-4405-b997-a7e49fe3b50c" />

<img width="2152" height="324" alt="image" src="https://github.com/user-attachments/assets/2505e93a-33b0-426f-8605-08f888fc30fc" />

