### PR TITLE
With Firefox, sometimes the FileManager UI does not load #57

### DIFF
--- a/ui/src/main/resources/FileManagerCode/DriveSheet.xml
+++ b/ui/src/main/resources/FileManagerCode/DriveSheet.xml
@@ -593,6 +593,7 @@
   },
   shim: {
     angular: {
+      deps: ['jquery'],
       exports: 'angular'
     },
     'angular-resource': {


### PR DESCRIPTION
# Issue URL

Fixes #57

# Changes

## Description

* Added explicit dependency on jquery in angular import

## Clarifications

* For some reason, firefox didn't load jquery and angular in the right order

# Executed Tests

Manual. I didn't get the error on firefox after applying the patch, no matter how many times I refreshed or cleared the cache.

* [ ] I checked the accessibility of this change (if you don't know what this is about or how to do it, leave this unchecked and don't worry)

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
