### PR TITLE
The Avatar image is broken when filtering by Author in the LiveTable #147

### DIFF
--- a/ui/src/main/resources/FileManagerCode/DriveSheet.xml
+++ b/ui/src/main/resources/FileManagerCode/DriveSheet.xml
@@ -948,7 +948,7 @@ require(['jquery', 'angular', 'JobRunner', 'xwiki-l10n!filemanager-drivesheet-tr
       };
       var prefix = 'property.XWiki.XWikiUsers.';
       for (var key in solrDoc) {
-        if (key.substr(0, prefix.length) == prefix) {
+        if (key.substr(0, prefix.length) == prefix &amp;&amp; (key.endsWith('_string') || key.endsWith('_boolean'))) {
           var property = key.substr(prefix.length);
           if (property.substr(-2) == '__') {
             property = property.substr(0, property.length - 2);


### PR DESCRIPTION
# Issue URL

<!-- Add the link to the corresponding issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
fixes #147 

# Changes

## Description

* Restricted solr property filter in javascript

## Clarifications

* New XWiki versions added some lowercase-only string properties. FileManager code always overwrites the user properties, so the final object will have the value of the last processed property.
* By doing this fix, the following properties won't exist anymore on the user object: address,comment
  * Those properties are never used in FileManager code, so it should be fine

Example solr result for 15.10:
```
// ...
property.XWiki.XWikiUsers.avatar_en: ['Image.png']
property.XWiki.XWikiUsers.avatar_string: ['Image.png']
// ...
```

Example solr result for 18.4.x:
```
// ...
property.XWiki.XWikiUsers.avatar_en: ['Image.png']
property.XWiki.XWikiUsers.avatar_sortString: "image.png"
property.XWiki.XWikiUsers.avatar_string: ['Image.png']
property.XWiki.XWikiUsers.avatar_string_lowercase: ['image.png']
// ...
```
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual

* [ ] I checked the accessibility of this change (if you don't know what this is about or how to do it, leave this unchecked and don't worry)

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->